### PR TITLE
Copy patches to Refasmer src dir to apply them

### DIFF
--- a/util/prereq.sh
+++ b/util/prereq.sh
@@ -40,7 +40,13 @@ clone_and_patch_refasm() {
       git reset --hard dea5ef565854209bb2dfb8c911e830f5abbf9422
     fi
     if [ ! -n "${NOPATCH:-}" ]; then
-      git am ${ABS_PATCH_DIR}/*.patch
+      # if you try to apply the patches directly,
+      # git says the files cannot be found.
+      # but copying them works.
+      for f in ${ABS_PATCH_DIR}/*.patch; do
+          cp ${f} .
+      done
+      git am *.patch
     fi
   )
 }


### PR DESCRIPTION
On my installation of Cygwin, trying to apply the patches using the absolute path does not work - git says the file cannot be found. Copying the patches to the source directory and applying them from there works fine, though.